### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/benpate/derp/security/code-scanning/1](https://github.com/benpate/derp/security/code-scanning/1)

The best general fix is to explicitly add a `permissions:` block at the workflow-level (root scope, just after the `name:` or `on:` key) or at the job level, specifying the narrowest required permission—`contents: read` should suffice for all shown steps. This prevents the workflow from running with higher permissions than necessary and follows GitHub’s security guidelines.  
To implement the fix, insert the following after the `name: Go` statement (line 1 or line 2):  
```yaml
permissions:
  contents: read
```  
No new methods or external changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
